### PR TITLE
Revamp the parsing logic for user inputs on stdin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(bpfd-bcc bcc-deps/bcc_elf.c bcc-deps/bcc_perf_map.c bcc-deps/bcc_pro
 			bcc-deps/vendor/tinyformat.hpp)
 target_link_libraries(bpfd-bcc ${LIBELF_LIBRARIES} ${ZLIB_LIBRARIES})
 
-add_executable(bpfd src/bpfd.c src/base64.c src/remote_perf_reader.c src/utils.c)
+add_executable(bpfd src/bpfd.c src/base64.c src/remote_perf_reader.c src/utils.c
+			src/cmd_parsers.c)
 target_link_libraries(bpfd bpfd-bpf)
 target_link_libraries(bpfd bpfd-bcc)

--- a/src/bpfd.h
+++ b/src/bpfd.h
@@ -17,70 +17,40 @@
  * limitations under the License.
  */
 
-#include <inttypes.h>
-
 #include "utils.h"
 #include "base64.h"
 #include "libbpf.h"
+#include "cmd_parsers.h"
 
-#define PARSE_INT(var)				\
-	tok = strtok(NULL, " ");		\
-	if (!tok)				\
-		goto invalid_command;		\
-	if (!sscanf(tok, "%d ", &var))		\
-		goto invalid_command;
+#define PARSE_INT(var)						\
+{								\
+	int p = parse_int_arg(in, arg_index++, &var);		\
+	if (p) goto invalid_command;				\
+}
 
-#define PARSE_UINT(var)				\
-	tok = strtok(NULL, " ");		\
-	if (!tok)				\
-		goto invalid_command;		\
-	if (!sscanf(tok, "%u ", &var))		\
-		goto invalid_command;
+#define PARSE_UINT(var)						\
+{								\
+	int p = parse_uint_arg(in, arg_index++, &var);		\
+	if (p) goto invalid_command;				\
+}
 
-#define PARSE_UINT64(var)			\
-	tok = strtok(NULL, " ");		\
-	if (!tok)				\
-		goto invalid_command;		\
-	if (!sscanf(tok, "%"SCNu64" ", &var))	\
-		goto invalid_command;
+#define PARSE_UINT64(var)					\
+{								\
+	int p = parse_uint64_arg(in, arg_index++, &var);	\
+	if (p) goto invalid_command;				\
+}
 
-#define PARSE_ULL(var)				\
-	tok = strtok(NULL, " ");		\
-	if (!tok)				\
-		goto invalid_command;		\
-	if (!sscanf(tok, "%llu ", &var))	\
-		goto invalid_command;
+#define PARSE_ULL(var)						\
+{								\
+	int p = parse_ull_arg(in, arg_index++, &var);		\
+	if (p) goto invalid_command;				\
+}
 
-#define PARSE_STR(var)				\
-	tok = strtok(NULL, " ");		\
-	if (!tok)				\
-		goto invalid_command;		\
-	var = tok;
-
-#define PARSE_FIRST_TOK				\
-	len = strlen(argstr);			\
-	tok = strtok(argstr, " ");		\
-	if (strlen(tok) == len)			\
-		goto invalid_command;
-
-#define PARSE_FIRST_INT(var)		\
-	PARSE_FIRST_TOK					\
-	if (!sscanf(tok, "%d ", &var))	\
-		goto invalid_command;
-
-#define PARSE_FIRST_UINT(var)		\
-	PARSE_FIRST_TOK					\
-	if (!sscanf(tok, "%u ", &var))	\
-		goto invalid_command;
-
-#define PARSE_FIRST_UINT64(var)		\
-	PARSE_FIRST_TOK					\
-	if (!sscanf(tok, "%"SCNu64" ", &var))	\
-		goto invalid_command;
-
-#define PARSE_FIRST_STR(var)		\
-	PARSE_FIRST_TOK					\
-	var = tok;
+#define PARSE_STR(var)						\
+{								\
+	int p = parse_str_arg(in, arg_index++, &var);		\
+	if (p) goto invalid_command;				\
+}
 
 int bpf_remote_open_perf_buffer(int pid, int cpu, int page_cnt);
 int remote_perf_reader_poll(int *fds, int len, int timeout);

--- a/src/cmd_parsers.c
+++ b/src/cmd_parsers.c
@@ -1,0 +1,140 @@
+/*
+ * BPFd (Berkeley Packet Filter daemon)
+ *
+ * Copyright (C) 2018 Jazel Canseco <jcanseco@google.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cmd_parsers.h"
+
+int count_num_tokens(const char *str)
+{
+	char *str_copy = NULL;
+	int num_tokens = 0;
+	char *token = NULL;
+
+	str_copy = (char *)malloc(strlen(str) + 1);
+	strcpy(str_copy, str);
+
+	for (token = strtok(str_copy, " ");
+	     token != NULL;
+	     token = strtok(NULL, " ")) {
+		num_tokens++;
+	}
+
+	free(str_copy);
+	return num_tokens;
+}
+
+struct user_input *parse_user_input(const char *str)
+{
+	struct user_input *in = NULL;
+	char *str_copy = NULL, *token = NULL;
+	int arg_index = 0, num_tokens = 0;
+
+	num_tokens = count_num_tokens(str);
+
+	in = (struct user_input *)malloc(sizeof(struct user_input));
+	in->num_args = num_tokens > 1 ? num_tokens - 1 : 0;
+	in->args = in->num_args > 0 ? (char **)malloc(in->num_args * sizeof(char *)) : NULL;
+
+	if (num_tokens == 0) {
+		in->cmd = NULL;
+		return in;
+	}
+
+	str_copy = (char *)malloc(strlen(str) + 1);
+	strcpy(str_copy, str);
+
+	token = strtok(str_copy, " ");
+	in->cmd = (char *)malloc(strlen(token) + 1);
+	strcpy(in->cmd, token);
+
+	if(in->num_args > 0) {
+		while((token = strtok(NULL, " "))) {
+			in->args[arg_index] = (char *)malloc(strlen(token) + 1);
+			strcpy(in->args[arg_index], token);
+			arg_index++;
+		}
+	}
+
+	free(str_copy);
+	return in;
+}
+
+void free_user_input(struct user_input *in)
+{
+	int i;
+
+	if (!in)
+		return;
+
+	if (in->cmd)
+		free(in->cmd);
+
+	if (in->args) {
+		for (i = 0; i < in->num_args; i++)
+			free(in->args[i]);
+
+		free(in->args);
+	}
+
+	free(in);
+}
+
+int parse_int_arg(const struct user_input *in, int index, int *val)
+{
+	if (index < 0 || index > in->num_args - 1)
+		return -1;
+
+	return !(sscanf(in->args[index], "%d", val) == 1);
+}
+
+int parse_uint_arg(const struct user_input *in, int index, unsigned int *val)
+{
+	if (index < 0 || index > in->num_args - 1)
+		return -1;
+
+	return !(sscanf(in->args[index], "%u", val) == 1);
+}
+
+int parse_uint64_arg(const struct user_input *in, int index, uint64_t *val)
+{
+	if (index < 0 || index > in->num_args - 1)
+		return -1;
+
+	return !(sscanf(in->args[index], "%"SCNu64"", val) == 1);
+}
+
+int parse_ull_arg(const struct user_input *in, int index, unsigned long long *val)
+{
+	if (index < 0 || index > in->num_args - 1)
+		return -1;
+
+	return !(sscanf(in->args[index], "%llu", val) == 1);
+}
+
+int parse_str_arg(const struct user_input *in, int index, char **val)
+{
+	if (index < 0 || index > in->num_args - 1)
+		return -1;
+
+	*val = in->args[index];
+	return 0;
+}

--- a/src/cmd_parsers.h
+++ b/src/cmd_parsers.h
@@ -1,0 +1,49 @@
+/*
+ * BPFd (Berkeley Packet Filter daemon)
+ *
+ * Copyright (C) 2018 Jazel Canseco <jcanseco@google.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+struct user_input {
+	char *cmd;
+	char **args;
+	int num_args;
+};
+
+/*
+ * Parses the string into a user_input struct object.
+ * The string is assumed to take the format of
+ *
+ * 	cmd arg1 arg2 arg3 ... argn
+ *
+ * If no cmd is provided (i.e. an empty string), the 'cmd' and 'args' fields are set to NULL.
+ * If a cmd is provided, but with no args, only the 'args' field is set to NULL.
+ */
+struct user_input *parse_user_input(const char *str);
+
+/*
+ * Frees user_input struct objects and their contents.
+ */
+void free_user_input(struct user_input *in);
+
+/*
+ * Functions for parsing arguments encapsulated by the user_input struct.
+ * Returns 0 on success.
+ */
+int parse_int_arg(const struct user_input *in, int index, int *val);
+int parse_uint_arg(const struct user_input *in, int index, unsigned int *val);
+int parse_uint64_arg(const struct user_input *in, int index, uint64_t *val);
+int parse_ull_arg(const struct user_input *in, int index, unsigned long long *val);
+int parse_str_arg(const struct user_input *in, int index, char **val);


### PR DESCRIPTION
This centralizes the parsing logic for user inputs on stdin into one
component, 'cmd_parsers.c', and encapsulates the relevant data (i.e. the BPFd
command and its arguments) into one data structure, the 'user_inputs'
struct. This effectively leads to the removal of all the confusing
pointer manipulation logic in the main while loop in bpfd.c that dealt with
user input parsing.

This also leads to the reduction of side effects caused by the PARSE
macros, since the PARSE macros themselves no longer need to do any
string tokenization using strtok().

Additionally, this also eliminates the PARSE_FIRST macros, and fixes the
bug where BPFd was unable to accept commands with less than 2 arguments,
forcing users to add an additional dummy argument.

Signed-off-by: Jazel Canseco <jcanseco@google.com>

Fixes #16 