### PR TITLE
Modify CMakeLists to support dynamic linking for x86 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,24 +9,27 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(ZLIB REQUIRED)
 find_package(LibElf REQUIRED)
 
-set(CMAKE_C_FLAGS "-static")
-set(CMAKE_CXX_FLAGS "-static")
-
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 11)
+
+IF(CMAKE_CROSSCOMPILING)
+	set(CMAKE_C_FLAGS "-static")
+	set(CMAKE_CXX_FLAGS "-static")
+	set(lib_type STATIC)
+ELSE()
+	set(lib_type SHARED)
+ENDIF()
 
 include_directories(src)
 include_directories(bcc-deps)
 include_directories(bcc-deps/compat)
 
-add_library(bpfd-bpf bcc-deps/libbpf.c bcc-deps/perf_reader.c)
-
-add_library(bpfd-bcc bcc-deps/bcc_elf.c bcc-deps/bcc_perf_map.c bcc-deps/bcc_proc.c
-			bcc-deps/bcc_syms.cc bcc-deps/ns_guard.cc bcc-deps/common.cc
-			bcc-deps/vendor/tinyformat.hpp)
+add_library(bpfd-bcc ${lib_type} bcc-deps/libbpf.c bcc-deps/perf_reader.c
+	bcc-deps/bcc_elf.c bcc-deps/bcc_perf_map.c bcc-deps/bcc_proc.c
+	bcc-deps/bcc_syms.cc bcc-deps/ns_guard.cc bcc-deps/common.cc
+	bcc-deps/vendor/tinyformat.hpp)
 target_link_libraries(bpfd-bcc ${LIBELF_LIBRARIES} ${ZLIB_LIBRARIES})
 
 add_executable(bpfd src/bpfd.c src/base64.c src/remote_perf_reader.c src/utils.c
 			src/cmd_parsers.c)
-target_link_libraries(bpfd bpfd-bpf)
 target_link_libraries(bpfd bpfd-bcc)


### PR DESCRIPTION
This adds support for bpfd builds that dynamically link to its
libraries. This is done only for x86 builds; arm64 builds continue to be
static as before.

This also consolidates the bcc functionality depended on by bpfd into one
library, 'libbpfd-bcc', as opposed to before where it was split into two
libraries, one for bpf-specific functionality ('libbpfd-bpf'), and one for
the rest of bcc depedencies ('libbpfd-bcc'). This was done since there
was little reason to keep them separate.

Signed-off-by: Jazel Canseco <jcanseco@google.com>

Fixes #38 