### PR TITLE
Poll stdin as well when polling perf_readers

### DIFF
--- a/src/bpfd.h
+++ b/src/bpfd.h
@@ -53,4 +53,4 @@
 }
 
 int bpf_remote_open_perf_buffer(int pid, int cpu, int page_cnt);
-int remote_perf_reader_poll(int *fds, int len, int timeout);
+int remote_perf_reader_poll(int *fds, int num_readers, int timeout);


### PR DESCRIPTION
This modifies the perf_reader polling logic for bpfd to include stdin
into the collection of file descriptors to poll when polling perf_reader
file descriptors.

This allows bpfd to be able to react to user input via stdin immediately as
opposed to before where it had to wait for the poll() to return before it
could address user input.

This fixes a bug where bcc tools like opensnoop.py refused to terminate
right away when interrupted with SIGINT (for example via Ctrl+C) since
it was still waiting for bpfd to respond to a command that bpfd failed to
respond to right away since it was still waiting for poll() to return.

Signed-off-by: Jazel Canseco <jcanseco@google.com>

Fixes #18 