### PR TITLE
Add support for bpf_attach_perf_event

### DIFF
--- a/src/bpfd.c
+++ b/src/bpfd.c
@@ -589,6 +589,23 @@ int main(int argc, char **argv)
 
 			printf("bpf_attach_tracepoint: ret=%d\n", ret);
 
+		} else if (!strcmp(in->cmd, "BPF_ATTACH_PERF_EVENT")) {
+			int ret, progfd, pid, cpu, group_fd;
+			uint32_t ev_type, ev_config;
+			uint64_t sample_period, sample_freq;
+
+			PARSE_INT(progfd);
+			PARSE_UINT32(ev_type);
+			PARSE_UINT32(ev_config);
+			PARSE_UINT64(sample_period);
+			PARSE_UINT64(sample_freq);
+			PARSE_INT(pid);
+			PARSE_INT(cpu);
+			PARSE_INT(group_fd);
+
+			ret = bpf_attach_perf_event(progfd, ev_type, ev_config,
+				sample_period, sample_freq, pid, cpu, group_fd);
+			printf("bpf_attach_perf_event: ret=%d\n", ret);
 		} else if (!strcmp(in->cmd, "BPF_CREATE_MAP")) {
 			/*
 				int bpf_create_map(enum bpf_map_type map_type, const char *name,

--- a/src/bpfd.h
+++ b/src/bpfd.h
@@ -34,6 +34,12 @@
 	if (p) goto invalid_command;				\
 }
 
+#define PARSE_UINT32(var)					\
+{								\
+	int p = parse_uint32_arg(in, arg_index++, &var);	\
+	if (p) goto invalid_command;				\
+}
+
 #define PARSE_UINT64(var)					\
 {								\
 	int p = parse_uint64_arg(in, arg_index++, &var);	\

--- a/src/cmd_parsers.c
+++ b/src/cmd_parsers.c
@@ -114,6 +114,14 @@ int parse_uint_arg(const struct user_input *in, int index, unsigned int *val)
 	return !(sscanf(in->args[index], "%u", val) == 1);
 }
 
+int parse_uint32_arg(const struct user_input *in, int index, uint64_t *val)
+{
+	if (index < 0 || index > in->num_args - 1)
+		return -1;
+
+	return !(sscanf(in->args[index], "%"SCNu32"", val) == 1);
+}
+
 int parse_uint64_arg(const struct user_input *in, int index, uint64_t *val)
 {
 	if (index < 0 || index > in->num_args - 1)

--- a/src/cmd_parsers.h
+++ b/src/cmd_parsers.h
@@ -44,6 +44,7 @@ void free_user_input(struct user_input *in);
  */
 int parse_int_arg(const struct user_input *in, int index, int *val);
 int parse_uint_arg(const struct user_input *in, int index, unsigned int *val);
+int parse_uint32_arg(const struct user_input *in, int index, uint64_t *val);
 int parse_uint64_arg(const struct user_input *in, int index, uint64_t *val);
 int parse_ull_arg(const struct user_input *in, int index, unsigned long long *val);
 int parse_str_arg(const struct user_input *in, int index, char **val);


### PR DESCRIPTION
This fixes the bug where tools that needed to attach to a perf_event
(like profile.py) were crashing due to BCC's lack of support for
attaching to remote perf_events.

Signed-off-by: Jazel Canseco <jcanseco@google.com>

When approving this PR, please approve the corresponding [BCC PR](https://github.com/joelagnel/bcc/pull/13) as well.
Fixes #31 