### PR TITLE
Remove lost_cb callback for remote_perf_reader

### DIFF
--- a/src/remote_perf_reader.c
+++ b/src/remote_perf_reader.c
@@ -71,16 +71,11 @@ void remote_raw_reader_cb(void *cookie, void *raw, int size)
 	free(raw_str);
 }
 
-void remote_lost_reader_cb(void *ptr, uint64_t lost)
-{
-}
-
 int bpf_remote_open_perf_buffer(int pid, int cpu, int page_cnt)
 {
 	struct perf_reader *reader;
 
-	reader = bpf_open_perf_buffer(remote_raw_reader_cb, remote_lost_reader_cb,
-								  NULL, pid, cpu, page_cnt);
+	reader = bpf_open_perf_buffer(remote_raw_reader_cb, NULL, NULL, pid, cpu, page_cnt);
 	if (!reader)
 		return -1;
 


### PR DESCRIPTION
Some BCC tools pass NULL for the lost_cb parameter in bpf_open_perf_buffer(),
which suggest that it is fine (and probably preferable) if we pass NULL for the
lost_cb callback instead of passing in a callback function that does nothing.

Signed-off-by: Jazel Canseco <jcanseco@google.com>